### PR TITLE
ELM-178 Serialize schema for Collection field

### DIFF
--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -509,6 +509,14 @@ class Swagger(object):
                 'items': self.serialize_schema(model),
             }
 
+        elif isinstance(model, fields.Collection):
+            self.register_field(model)
+            model = model.container
+            return {
+                'type': 'object',
+                'additionalProperties': self.serialize_schema(model),
+            }
+
         elif isinstance(model, ModelBase):
             self.register_model(model)
             return ref(model)

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -511,10 +511,15 @@ class Swagger(object):
 
         elif isinstance(model, fields.Collection):
             self.register_field(model)
-            model = model.container
+            if model.example is not None:
+                return {
+                    'type': 'object',
+                    'additionalProperties': self.serialize_schema(model.container),
+                    'example': model.example,
+                }
             return {
                 'type': 'object',
-                'additionalProperties': self.serialize_schema(model),
+                'additionalProperties': self.serialize_schema(model.container),
             }
 
         elif isinstance(model, ModelBase):

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -315,6 +315,13 @@ class Swagger(object):
                         'in': 'body',
                         'schema': self.serialize_schema(expect),
                     })
+            elif isinstance(expect, fields.Collection):
+                params['payload'] = not_none({
+                    'name': 'payload',
+                    'required': True,
+                    'in': 'body',
+                    'schema': self.serialize_schema(expect),
+                })
         return params
 
     def register_errors(self):


### PR DESCRIPTION
Issue: API Response does not register Collection field and the model in it.
When api response model defined to be a Collection field, the container object (declared in additionalProperties field) is not registered to swagger definition.
As a result, the swagger are missing the definition of this item and throw error.

- [x] I updated `serialize_schema` (which is called when adding responses documentation) and add cases for when the model is a Collection. (parallel to reponse object as list)
The method will look into the container (item) and register that model. It will then serialize the nested item and return the reference for documentation purposes.
- [x] I added example when serializing schema Collection field, when available

- [x] I updated `expected_param`, (which is called when adding expect/ request documentation) and add cases when the model is a Collection

Things to do on next iteration/ update
- [ ] Allow validating expect on fields.Collection

Please review
@darkvariantdivine @keerthibalan 